### PR TITLE
Allow custom `DATABASE_URL` env in dev

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+# .env
+#
+# This is a sample file. Duplicate it as `.env` and customize it to your needs.
+#
+#     # eg.:
+#     $ cp .env.sample .env
+
+export DATABASE_URL="postgres://postgres:postgres@localhost/game_dev"

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ npm-debug.log
 
 # postgres logfile
 logfile
+
+# direnv files
+.env
+.envrc

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,10 +2,7 @@ import Config
 
 # Configure your database
 config :game, Game.Repo,
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
-  database: "game_dev",
+  url: System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost/game_dev"),
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10


### PR DESCRIPTION
It allows dev-specific customizations to the database settings, eg: to use custom user, pass, etc., set in .env files - which are also ignored in .gitignore.

See: https://direnv.net